### PR TITLE
Fix a bug for Apple Git

### DIFF
--- a/lib/Test/Requires/Git.pm
+++ b/lib/Test/Requires/Git.pm
@@ -85,7 +85,7 @@ sub test_requires_git {
     # get the git version
     my ($version) = do {
         no warnings 'uninitialized';
-        __PACKAGE__->_git_version() =~ /^git version (.*)/g;
+        __PACKAGE__->_git_version() =~ /^git version ([^\s]*)/g;
     };
 
     # perform the check


### PR DESCRIPTION
Hi. `Test::Requires::Git` doesn't work in Mac OS X with Apple Git.

Thank you.

```
$ uname -a
Darwin shinoa.local 15.0.0 Darwin Kernel Version 15.0.0: Wed Aug 26 16:57:32 PDT 2015; root:xnu-3247.1.106~1/RELEASE_X86_64 x86_64

$ which git
/usr/bin/git

$ git --version
git version 2.6.4 (Apple Git-63)

$ prove --lib -r t
t/fail.t ............ 1/7
#   Failed test '... expected error message'
#   at t/fail.t line 10.
#                   '2.6.4 (Apple Git-63) does not look like a Git version at /Users/pine/project/Test-Requires-Git/lib/Test/Requires/Git.pm line 95.
# '
#     doesn't match '(?^:^zlonk does not look like a Git version )'
Can't exec "git": No such file or directory at /Users/pine/project/Test-Requires-Git/lib/Test/Requires/Git.pm line 78.
# Looks like you failed 1 test of 7.
t/fail.t ............ Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/7 subtests
        (less 1 skipped subtest: 5 okay)
t/has_plan.t ........ ok
t/import.t .......... 1/2
#   Failed test '... expected error message'
#   at t/import.t line 9.
#                   '2.6.4 (Apple Git-63) does not look like a Git version at /Users/pine/project/Test-Requires-Git/lib/Test/Requires/Git.pm line 95.
# BEGIN failed--compilation aborted at (eval 4) line 1.
# '
#     doesn't match '(?^:^-bonk does not look like a Git version )'
# Looks like you failed 1 test of 2.
t/import.t .......... Dubious, test returned 1 (wstat 256, 0x100)
```
